### PR TITLE
fix: 🐛 compatibility with Prettier VSCode extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "main": "dist/index.js",
   "exports": {
     ".": {
-      "import": "./dist/index.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "node": "./dist/index.js"
     }
   },
   "files": ["dist", "src"],

--- a/package.json
+++ b/package.json
@@ -8,13 +8,7 @@
     "node": ">= 20.9 < 24"
   },
   "main": "dist/index.js",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "node": "./dist/index.js"
-    }
-  },
+  "exports": "./dist/index.js",
   "files": ["dist", "src"],
   "dependencies": {
     "tslib": "~2.7"


### PR DESCRIPTION
Hi, Takashi!
Thanks for the helpful plugin!

### :monocle_face: The Problem
Without the `node` condition in the `exports` field of `package.json`, the VSCode Prettier extension could not resolve the plugin and errored with the message `Error resolve node module '@ttskch/prettier-plugin-tailwindcss-anywhere'` in the output.

### :bulb: The Solution
Adding the `node` condition ensures proper resolution in Node-based environments, and `types` enables TypeScript support.